### PR TITLE
Use React.cloneElement to keep refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _site
 *.zip
 *.vi
 *~
+*.log.*
 
 # OS or Editor folders
 .DS_Store

--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 var React = require('react');
+var ReactDOM = require('react-dom');
 var Layout = require('../');
 
 var VerticalLayout = React.createClass({
@@ -7,13 +8,20 @@ var VerticalLayout = React.createClass({
       <Layout layoutWidth={this.props.width} layoutHeight={this.props.height}>
         <Layout className="nav" layoutHeight={100} style={{background: 'pink'}}>
           <div>nav</div>
+          <input type='text' />
         </Layout>
-        <Layout className="main" layoutHeight="flex" style={{background: 'lightblue'}}>
-          <div>main</div>
+        <Layout layoutHeight='flex'>
+          <Layout className="sidebar" layoutWidth={300} style={{background: 'darkblue', float: 'left'}}>
+            <div>Sidebar</div>
+          </Layout>
+          <Layout className="main" layoutWidth="flex" style={{background: 'lightgreen', float: 'right'}}>
+            <div>Main</div>
+            <input type='text' ref={(c) => c.focus()} />
+          </Layout>
         </Layout>
       </Layout>
     )
-  },
+  }
 })
 
 function render() {
@@ -23,7 +31,7 @@ function render() {
       height={window.innerHeight}
     />
   )
-  React.render(appView, document.body)
+  ReactDOM.render(appView, document.body)
 }
 
 window.addEventListener('resize', render)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "browserify-incremental": "^1.5.0",
     "coffee-script": "^1.7.1",
     "node-jsx": "^0.12.0",
-    "react": "^0.13.0",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
     "tap": "^0.4.13",
     "watchy": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "browserify-incremental": "^1.5.0",
     "coffee-script": "^1.7.1",
     "node-jsx": "^0.12.0",
-    "react": "^0.12.0",
+    "react": "^0.13.0",
     "tap": "^0.4.13",
     "watchy": "^0.6.0"
   },

--- a/src/mixin.coffee
+++ b/src/mixin.coffee
@@ -5,16 +5,16 @@ merge = clone = require('xtend')
 
 DIMENSIONS = ['height','width']
 
-LayoutMixin = 
-  contextTypes: 
-    layoutContext: React.PropTypes.object,
- 
-  childContextTypes: 
+LayoutMixin =
+  contextTypes:
     layoutContext: React.PropTypes.object,
 
-  getChildContext: ->   
+  childContextTypes:
+    layoutContext: React.PropTypes.object,
+
+  getChildContext: ->
     layoutContext: @getLayoutContext(),
-  
+
   getLayoutContext: ->
     inherited = @props.layoutContext or @context.layoutContext
     if inherited?
@@ -55,15 +55,13 @@ LayoutMixin =
           precalc[dim].fixedSum += def[dim]
         else if layoutIsFlex(def[dim])
           precalc[dim].flexChildren++
-       
+
     # calc and apply layout to each child
     React.Children.map children, (child) ->
       # only apply to component-like objects (which have props)
       return child unless child?.props
-      # skip children with refs (because they can't safely be cloned)
-      return child if child.props.ref?
       # 'layout' here refers to the calculated layout for the child,
-      # which will inform that child's layoutContext 
+      # which will inform that child's layoutContext
       # (and any of its children which inherit it)
       layout = clone(parentLayout)
       def = getLayoutDef(child)
@@ -75,7 +73,7 @@ LayoutMixin =
             flexSizeForDimension = (parentLayout[dim] - precalc[dim].fixedSum) / precalc[dim].flexChildren
             layout[dim] = flexSizeForDimension
 
-      React.addons.cloneWithProps child, layoutContext: layout
+      React.cloneElement child, layoutContext: layout
 
 getLayoutDef = (component) ->
   return unless hasReactLayout(component)

--- a/src/mixin.coffee
+++ b/src/mixin.coffee
@@ -1,5 +1,5 @@
 
-React = require('react/addons')
+React = require('react')
 
 merge = clone = require('xtend')
 


### PR DESCRIPTION
Using `React.cloneElement` instead of `React.addons.cloneWithProps` to keep elements' refs
Addressing the issue https://github.com/jsdf/react-layout/issues/9
